### PR TITLE
Update config.rst

### DIFF
--- a/docs/install/config.rst
+++ b/docs/install/config.rst
@@ -536,6 +536,15 @@ Who should be emailed when internal QATrack+ errors occur:
     )
     MANAGERS = ADMINS
 
+Default Sender
+~~~~~~~~~~~
+The default "from" address for notification emails (e.g. password reset requests):
+
+.. code-block:: python
+
+    DEFAULT_FROM_EMAIL = email@yourplace.com
+
+This may need to be the same as EMAIL_HOST_USER depending on server settings
 
 
 Email host settings

--- a/docs/install/config.rst
+++ b/docs/install/config.rst
@@ -542,7 +542,7 @@ The default "from" address for notification emails (e.g. password reset requests
 
 .. code-block:: python
 
-    DEFAULT_FROM_EMAIL = email@yourplace.com
+    DEFAULT_FROM_EMAIL = "email@yourplace.com"
 
 This may need to be the same as EMAIL_HOST_USER depending on server settings
 


### PR DESCRIPTION
Add "DEFAULT_FROM_EMAIL", without which password reset notifications on my install would fail with the error
`smtplib.SMTPSenderRefused: (504, b'5.5.2 <webmaster@localhost>: Sender address rejected: need fully-qualified address', 'webmaster@localhost')`
Other notifications (e.g. fault logged) worked without this setting