### PR TITLE
Update views.py - move create comment earlier

### DIFF
--- a/qatrack/faults/views.py
+++ b/qatrack/faults/views.py
@@ -418,16 +418,6 @@ def save_valid_fault_form(form, request):
     fault.modified_by = request.user
     fault.save()
 
-    new_faults = set(models.FaultType.objects.filter(code__in=form.cleaned_data['fault_types_field']))
-    cur_faults = set(fault.fault_types.all())
-    to_remove = cur_faults - new_faults
-    to_add = new_faults - cur_faults
-    fault.fault_types.remove(*to_remove)
-    fault.fault_types.add(*to_add)
-    related_service_events = form.cleaned_data.get('related_service_events', [])
-    sers = sl_models.ServiceEvent.objects.filter(pk__in=related_service_events)
-    fault.related_service_events.set(sers)
-
     comment = form.cleaned_data.get('comment', '')
     if comment:
         comment = Comment(
@@ -438,6 +428,16 @@ def save_valid_fault_form(form, request):
             site=get_current_site(request)
         )
         comment.save()
+
+    new_faults = set(models.FaultType.objects.filter(code__in=form.cleaned_data['fault_types_field']))
+    cur_faults = set(fault.fault_types.all())
+    to_remove = cur_faults - new_faults
+    to_add = new_faults - cur_faults
+    fault.fault_types.remove(*to_remove)
+    fault.fault_types.add(*to_add)
+    related_service_events = form.cleaned_data.get('related_service_events', [])
+    sers = sl_models.ServiceEvent.objects.filter(pk__in=related_service_events)
+    fault.related_service_events.set(sers)
 
     for f in request.FILES.getlist('fault-attachments'):
         Attachment.objects.create(


### PR DESCRIPTION
I was trying to add the comment content to "fault logged" email notifications, but realised the comment count was showing as 0 when the email was sent. I resolved this in my install by editing the faults views.py to move the comment creation (```comment = form.cleaned_data.get('comment', '') [...] comment.save()```) before the new fault and notification is triggered (```new_faults = set(models.FaultType.objects.filter(code__in=form.cleaned_data['fault_types_field']))
 ...```), therefore allowing comments to be included in notification templates.

I'm not certain what other impact this might have or if there is any reason for it to be done in the original order, but so far it appears to work for me

In the email template I used:
```
{% get_comment_list for fault as comment_list %}
{% for comment in comment_list %}
  {{ comment.comment }}
{% endfor %}
```