### PR TITLE
Fix some selenium tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ django_find_project = true
 DJANGO_SETTINGS_MODULE = "qatrack.settings"
 
 [tool.uv.sources]
-python-ldap = { url = "https://github.com/cgohlke/python-ldap-build/releases/download/v3.4.4-1/python_ldap-3.4.4-cp312-cp312-win_amd64.whl" }
+python-ldap = { url = "https://github.com/cgohlke/python-ldap-build/releases/download/v3.4.4-1/python_ldap-3.4.4-cp312-cp312-win_amd64.whl", marker = "sys_platform == 'windows'" }
 
 [dependency-groups]
 dev = [

--- a/qatrack/qa/tests/test_selenium.py
+++ b/qatrack/qa/tests/test_selenium.py
@@ -253,7 +253,7 @@ class LiveQATests(BaseQATests):
                     constant_value=the_test['constant_value'],
                 )
 
-        self.click_by_link_text("Test lists")
+        self.click_by_link_text("Test Lists")
         self.click_by_link_text("ADD TEST LIST")
         self.wait.until(e_c.presence_of_element_located((By.ID, 'id_name')))
         self.driver.find_element(By.ID, 'id_name').send_keys(objects['TestList']['name'])
@@ -268,7 +268,7 @@ class LiveQATests(BaseQATests):
     def test_admin_modality(self):
 
         self.load_admin()
-        self.click_by_link_text("Treatment and imaging modalities")
+        self.click_by_link_text("Treatment and Imaging Modalities")
         self.click_by_link_text("ADD TREATMENT AND IMAGING MODALITY")
         self.wait.until(e_c.presence_of_element_located((By.ID, 'id_name')))
         self.driver.find_element(By.ID, 'id_name').send_keys(objects['Modality']['name'])
@@ -278,7 +278,7 @@ class LiveQATests(BaseQATests):
     def test_admin_unittype(self):
 
         self.load_admin()
-        self.click_by_link_text("Unit types")
+        self.click_by_link_text("Unit Types")
         self.click_by_link_text("ADD UNIT TYPE")
         self.wait.until(e_c.presence_of_element_located((By.ID, 'id_name')))
         self.driver.find_element(By.ID, 'id_name').send_keys(objects['UnitType']['name'])
@@ -797,7 +797,7 @@ class TestPerformQC(BaseQATests):
         assert models.AutoSave.objects.count() == 0
         time.sleep(1)
         inputs[0].send_keys(Keys.ENTER)
-        time.sleep(2.1)  # auto save is debounced with a 2s interval
+        time.sleep(4.2)  # auto save is debounced with a 4s interval
         assert models.AutoSave.objects.count() == 1
 
     def test_load_autosave(self):

--- a/qatrack/qatrack_core/tests/live.py
+++ b/qatrack/qatrack_core/tests/live.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from functools import wraps
 import time
+import shutil
 
 from django.conf import settings
 from django.contrib.staticfiles.handlers import StaticFilesHandler
@@ -131,12 +132,11 @@ class SeleniumTests(StaticLiveServerSingleThreadedTestCase):
                 ff_options.add_argument('--disable-headless')
 
             firefox_driver_path = getattr(settings, 'SELENIUM_FIREFOX_DRIVER_PATH', '')
-            
             if firefox_driver_path:
                 service = FirefoxService(executable_path=firefox_driver_path)
             else:
                 # Try to use system geckodriver
-                service = FirefoxService(executable_path='/snap/bin/geckodriver')
+                service = FirefoxService(executable_path=shutil.which('geckodriver'))
                 
             cls.driver = webdriver.Firefox(service=service, options=ff_options)
 


### PR DESCRIPTION
Fixed a couple of selenium tests not passing due to typos.

That said, a couple of selenium tests still do not pass on my system.

In `pyproject.toml`, added the marker to indicate Windows platform for python-ldap in `[tool.uv.sources]`. python-ldap already provides wheels for linux on pypi, and without this marker, `uv sync` won't work on linux as it can only see the windows build.