### PR TITLE
docs(install): update Windows python-ldap wheels link to cgohlke fork (#678)

### DIFF
--- a/docs/install/authentication_backends.rst
+++ b/docs/install/authentication_backends.rst
@@ -32,7 +32,7 @@ Windows
 If you happen to be on a Windows system with Visual Studio installed, you
 should just be able to do `pip install python-ldap` and have the latest version of
 the pyldap package installed.  Otherwise,  there are binaries available on this
-page: https://www.lfd.uci.edu/~gohlke/pythonlibs/#python-ldap.  Download the binary
+page: https://github.com/cgohlke/python-ldap-build/releases.  Download the binary
 relevant to your Python 3 installation (e.g.
 python_ldap‑3.3.1‑cp36‑cp36m‑win_amd64.whl) and then pip install it:
 

--- a/docs/install/win.rst
+++ b/docs/install/win.rst
@@ -117,7 +117,7 @@ We're now ready to install all the libraries QATrack+ depends on.
     If you are going to be using :ref:`Active Directory <active_directory>` for
     authenticating your users, you need to install pyldap.  There are binaries
     available on this page:
-    https://www.lfd.uci.edu/~gohlke/pythonlibs/#python-ldap.  Download the
+    https://github.com/cgohlke/python-ldap-build/releases.  Download the
     binary relavant to your distribution (e.g.
     python_ldap‑3.3.1‑cp39‑cp39‑win_amd64.whl) and then pip install it:
 

--- a/docs/install/win_upgrade_from_030.rst
+++ b/docs/install/win_upgrade_from_030.rst
@@ -215,7 +215,7 @@ can take a few minutes!):
     If you are going to be using :ref:`Active Directory <active_directory>` for
     authenticating your users, you need to install pyldap.  There are binaries
     available on this page:
-    https://www.lfd.uci.edu/~gohlke/pythonlibs/#python-ldap.  Download the
+    https://github.com/cgohlke/python-ldap-build/releases.  Download the
     binary relavant to your distribution (e.g.
     python_ldap‑3.3.1‑cp39‑cp39‑win_amd64.whl) and then pip install it:
 


### PR DESCRIPTION
Closes #678.

Christoph Gohlke retired the `lfd.uci.edu/~gohlke/pythonlibs/` listing; the maintained Windows wheels for `python-ldap` now live at https://github.com/cgohlke/python-ldap-build/releases. Update the three install docs that referenced the old URL:

- `docs/install/authentication_backends.rst`
- `docs/install/win.rst`
- `docs/install/win_upgrade_from_030.rst`

The surrounding prose (filename example, pip install instructions) stays unchanged; only the URL is swapped.

### Change Type

- [x] Documentation