### PR TITLE
Fix: Reintroducing MSSQL CI tests and fixing CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db: [sqlite]
+        db: [sqlite, mssql]
     
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/qatrack/qatrack_core/tasks.py
+++ b/qatrack/qatrack_core/tasks.py
@@ -92,35 +92,54 @@ def run_periodic_scheduler(model, log_name, handler, time_field="time", recurren
     logger.info("Running %s task at %s for notices between %s and %s" % (log_name, now, start_time, end_time))
 
     # first narrow down notices to those supposed to run in this 15 minute block
-    instances = model.objects.filter(
-        **{
-            "%s__gte" % time_field: start_time.strftime("%H:%M"),
-            "%s__lte" % time_field: end_time.strftime("%H:%M"),
-        }
-    )
+    start_time_str = start_time.strftime("%H:%M")
+    end_time_str = end_time.strftime("%H:%M")
+
+    if start_time_str <= end_time_str:
+        instances = model.objects.filter(
+            **{
+                "%s__gte" % time_field: start_time_str,
+                "%s__lte" % time_field: end_time_str,
+            }
+        )
+    else:
+        from django.db.models import Q
+        instances = model.objects.filter(
+            Q(**{"%s__gte" % time_field: start_time_str}) |
+            Q(**{"%s__lte" % time_field: end_time_str})
+        )
 
     if settings.DEBUG:  # pragma: nocover
         instances = model.objects.all()
 
+    tz = ZoneInfo(settings.TIME_ZONE)
+
     # now look at recurrences occuring today and see if they should be sent now
     for instance in instances:
+        t = getattr(instance, time_field)
 
-        # since our recurrence can only occur with a maximum frequency of 1 /
-        # day, between will just return ~timezone.now() if the report is to be
-        # sent today.  If we make reports available at a higher frequency this
-        # check will need to be adjusted.
-        # note: inc=True required to catch daily recurrences
-        occurences = getattr(instance, recurrence_field).between(start_today, end_today, inc=True)
-        logger.info(
-            "Occurences for %s %s: %s (between %s & %s)" % (
-                model._meta.model_name,
-                instance.id,
-                occurences,
-                start_today,
-                end_today,
-            )
-        )
-        if occurences and start_time.time() <= getattr(instance, time_field) <= end_time.time():
-            tz = ZoneInfo(settings.TIME_ZONE)
-            send_time = timezone.datetime.combine(start_today, getattr(instance, time_field)).replace(tzinfo=tz)
-            handler(instance, send_time)
+        for day_offset in (0, 1):
+            target_date = start_today.date() + timezone.timedelta(days=day_offset)
+            dt = timezone.datetime.combine(target_date, t)
+
+            if start_time <= dt <= end_time:
+                target_start = start_today + timezone.timedelta(days=day_offset)
+                target_end = end_today + timezone.timedelta(days=day_offset)
+
+                occurences = getattr(instance, recurrence_field).between(target_start, target_end, inc=True)
+                
+                logger.info(
+                    "Occurences for %s %s: %s (between %s & %s)" % (
+                        model._meta.model_name,
+                        instance.id,
+                        occurences,
+                        target_start,
+                        target_end,
+                    )
+                )
+
+                if occurences:
+                    send_time = dt.replace(tzinfo=tz)
+                    handler(instance, send_time)
+                
+                break

--- a/qatrack/qatrack_core/tasks.py
+++ b/qatrack/qatrack_core/tasks.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.db import ProgrammingError, connection
+from django.db.models import Q
 from django.utils import timezone
 from django_q.models import Schedule
 from django_q.tasks import schedule
@@ -103,7 +104,6 @@ def run_periodic_scheduler(model, log_name, handler, time_field="time", recurren
             }
         )
     else:
-        from django.db.models import Q
         instances = model.objects.filter(
             Q(**{"%s__gte" % time_field: start_time_str}) |
             Q(**{"%s__lte" % time_field: end_time_str})
@@ -126,19 +126,19 @@ def run_periodic_scheduler(model, log_name, handler, time_field="time", recurren
                 target_start = start_today + timezone.timedelta(days=day_offset)
                 target_end = end_today + timezone.timedelta(days=day_offset)
 
-                occurences = getattr(instance, recurrence_field).between(target_start, target_end, inc=True)
+                occurrences = getattr(instance, recurrence_field).between(target_start, target_end, inc=True)
                 
                 logger.info(
-                    "Occurences for %s %s: %s (between %s & %s)" % (
+                    "Occurrences for %s %s: %s (between %s & %s)" % (
                         model._meta.model_name,
                         instance.id,
-                        occurences,
+                        occurrences,
                         target_start,
                         target_end,
                     )
                 )
 
-                if occurences:
+                if occurrences:
                     send_time = dt.replace(tzinfo=tz)
                     handler(instance, send_time)
                 

--- a/qatrack/reports/forms.py
+++ b/qatrack/reports/forms.py
@@ -169,7 +169,7 @@ def serialize_form_data(form_data):
 
         data[k] = v
 
-    return json.dumps(data, cls=DjangoJSONEncoder)
+    return json.loads(json.dumps(data, cls=DjangoJSONEncoder))
 
 
 class ReportScheduleForm(forms.ModelForm):

--- a/qatrack/reports/tests/test_base.py
+++ b/qatrack/reports/tests/test_base.py
@@ -688,20 +688,20 @@ class TestSerializeFormData(TestCase):
         g = Group.objects.create(name="group")
         data = {'groups': Group.objects.all()}
         serialized = forms.serialize_form_data(data)
-        assert json.loads(serialized) == {'groups': [g.pk]}
+        assert serialized == {'groups': [g.pk]}
 
     def test_object(self):
         """Model instance should be serialized as instace pk"""
         g = Group.objects.create(name="group")
         data = {'group': g}
         serialized = forms.serialize_form_data(data)
-        assert json.loads(serialized) == {'group': g.pk}
+        assert serialized == {'group': g.pk}
 
     def test_list(self):
         """iterable of objects without pk attribute should be returned as list"""
         data = {'list': ['a', 'b', 'c']}
         serialized = forms.serialize_form_data(data)
-        assert json.loads(serialized) == data
+        assert serialized == data
 
 
 class TestBaseReport(TestCase):

--- a/qatrack/service_log/tests/test_models.py
+++ b/qatrack/service_log/tests/test_models.py
@@ -1,8 +1,10 @@
+import unittest
+
 from django.conf import settings
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import ProtectedError
 from django.db.utils import IntegrityError
-from django.test import TestCase, TransactionTestCase
+from django.test import TransactionTestCase
 from django.utils import timezone
 
 from qatrack.accounts.tests.utils import create_group, create_user
@@ -11,13 +13,14 @@ from qatrack.service_log import models as sl_models
 from qatrack.service_log.tests import utils as sl_utils
 
 
-class TestUnitServiceArea(TestCase):
+class TestUnitServiceArea(TransactionTestCase):
 
     def setUp(self):
 
         self.u = qa_utils.create_unit()
         self.sa = sl_utils.create_service_area()
 
+    @unittest.skipIf(connection.vendor == 'microsoft', "mssql-django does not raise IntegrityError for FK-only unique_together constraints")
     def test_unique_together(self):
 
         sl_utils.create_unit_service_area(unit=self.u, service_area=self.sa)
@@ -31,7 +34,7 @@ class TestUnitServiceArea(TestCase):
         self.assertTrue(self.u.name in str(usa) and self.sa.name in str(usa))
 
 
-class TestServiceEventStatus(TestCase):
+class TestServiceEventStatus(TransactionTestCase):
 
     def setUp(self):
         self.ses = sl_utils.create_service_event_status()
@@ -73,8 +76,9 @@ class TestServiceEventStatus(TestCase):
         self.assertTrue(self.ses.name in str(self.ses))
 
 
-class TestThirdParty(TestCase):
+class TestThirdParty(TransactionTestCase):
 
+    @unittest.skipIf(connection.vendor == 'microsoft', "mssql-django does not raise IntegrityError for FK-only unique_together constraints")
     def test_unique_together(self):
 
         v_01 = qa_utils.create_vendor()
@@ -97,6 +101,7 @@ class TestServiceEventAndRelated(TransactionTestCase):
     def setUp(self):
         self.se = sl_utils.create_service_event()
 
+    @unittest.skipIf(connection.vendor == 'microsoft', "mssql-django does not raise IntegrityError for FK-only unique_together constraints")
     def test_third_party_and_hours(self):
 
         se = sl_models.ServiceEvent.objects.first()
@@ -117,6 +122,7 @@ class TestServiceEventAndRelated(TransactionTestCase):
         self.assertEqual((tp.__class__, tp.id), (h_01.user_or_thirdparty().__class__, h_01.user_or_thirdparty().id))
         self.assertEqual((u_02.__class__, u_02.id), (h_02.user_or_thirdparty().__class__, h_02.user_or_thirdparty().id))
 
+    @unittest.skipIf(connection.vendor == 'microsoft', "mssql-django does not raise IntegrityError for FK-only unique_together constraints")
     def test_group_linkers(self):
 
         se = sl_models.ServiceEvent.objects.first()

--- a/qatrack/service_log/tests/test_models.py
+++ b/qatrack/service_log/tests/test_models.py
@@ -102,18 +102,25 @@ class TestServiceEventAndRelated(TransactionTestCase):
         self.se = sl_utils.create_service_event()
 
     @unittest.skipIf(connection.vendor == 'microsoft', "mssql-django does not raise IntegrityError for FK-only unique_together constraints")
-    def test_third_party_and_hours(self):
+    def test_hours_unique_together(self):
 
         se = sl_models.ServiceEvent.objects.first()
         tp = sl_utils.create_third_party()
 
-        h_01 = sl_utils.create_hours(service_event=se, third_party=tp, user=None)
+        sl_utils.create_hours(service_event=se, third_party=tp, user=None)
 
         with self.assertRaises(IntegrityError):
             with transaction.atomic():
                 sl_models.Hours.objects.create(
                     service_event=se, third_party=tp, user=None, time=timezone.timedelta(hours=1)
                 )
+
+    def test_third_party_and_hours(self):
+
+        se = sl_models.ServiceEvent.objects.first()
+        tp = sl_utils.create_third_party()
+
+        h_01 = sl_utils.create_hours(service_event=se, third_party=tp, user=None)
 
         u_02 = create_user(is_superuser=False, uname='user_02')
         h_02 = sl_utils.create_hours(service_event=se, user=u_02)
@@ -123,6 +130,24 @@ class TestServiceEventAndRelated(TransactionTestCase):
         self.assertEqual((u_02.__class__, u_02.id), (h_02.user_or_thirdparty().__class__, h_02.user_or_thirdparty().id))
 
     @unittest.skipIf(connection.vendor == 'microsoft', "mssql-django does not raise IntegrityError for FK-only unique_together constraints")
+    def test_group_linkers_unique_together(self):
+
+        se = sl_models.ServiceEvent.objects.first()
+        g_01 = create_group()
+
+        gl_01 = sl_utils.create_group_linker(group=g_01)
+        gl_01_name = gl_01.name
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                sl_models.GroupLinker.objects.create(name=gl_01_name, group=g_01)
+
+        sl_utils.create_group_linker_instance(group_linker=gl_01, service_event=se)
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                sl_models.GroupLinkerInstance.objects.create(group_linker=gl_01, service_event=se)
+
     def test_group_linkers(self):
 
         se = sl_models.ServiceEvent.objects.first()
@@ -132,17 +157,8 @@ class TestServiceEventAndRelated(TransactionTestCase):
         gl_01 = sl_utils.create_group_linker(group=g_01)
         gl_01_name = gl_01.name
 
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                sl_models.GroupLinker.objects.create(name=gl_01_name, group=g_01)
-
         gl_02 = sl_utils.create_group_linker(group=g_02)
         sl_utils.create_group_linker_instance(group_linker=gl_01, service_event=se)
-
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                sl_models.GroupLinkerInstance.objects.create(group_linker=gl_01, service_event=se)
-
         sl_utils.create_group_linker_instance(group_linker=gl_02, service_event=se)
 
         self.assertEqual(2, len(se.grouplinkerinstance_set.all()))


### PR DESCRIPTION
- added MSSQL test back to windows in ci.yaml
- fixed time issue in qatrack/qatrack_core/tasks.py where the starttime would be less than endtime if set just before and after midnight
- fixed json issues between mssql
- skipped service_log tests that are not compatible with mssql