### PR TITLE
Fix(Attachments): add django system check to verify media directory w…

### DIFF
--- a/qatrack/qatrack_core/apps.py
+++ b/qatrack/qatrack_core/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class QATrackCoreConfig(AppConfig):
+    name = 'qatrack.qatrack_core'
+
+    def ready(self):
+        import qatrack.qatrack_core.checks  # noqa

--- a/qatrack/qatrack_core/checks.py
+++ b/qatrack/qatrack_core/checks.py
@@ -1,0 +1,59 @@
+import os
+import tempfile
+
+from django.conf import settings
+from django.core.checks import Error, register
+
+
+@register()
+def check_media_folder_permissions(app_configs, **kwargs):
+    errors = []
+    media_root = getattr(settings, 'MEDIA_ROOT', None)
+    
+    if not media_root:
+        return errors
+        
+    if not os.path.exists(media_root):
+        return errors
+        
+    uploads_dirs = [
+        media_root,
+        os.path.join(media_root, 'uploads'),
+        os.path.join(media_root, 'uploads', 'tmp'),
+    ]
+    
+    for directory in uploads_dirs:
+        if os.path.exists(directory):
+            if not os.access(directory, os.W_OK):
+                errors.append(
+                    Error(
+                        f"The Django server process does not have write permissions to '{directory}'.",
+                        hint=f"Check folder permissions. You may need to run `sudo chown -R www-data:www-data {media_root}` and `sudo chmod -R 775 {media_root}` (replace www-data with your web server user).",
+                        id='qatrack.E001',
+                    )
+                )
+            else:
+                try:
+                    fd, temp_path = tempfile.mkstemp(dir=directory)
+                    os.close(fd)
+                    os.remove(temp_path)
+                except Exception as e:
+                    errors.append(
+                        Error(
+                            f"The Django server process could not create a file in '{directory}': {e}",
+                            hint="Check folder permissions and disk space.",
+                            id='qatrack.E002',
+                        )
+                    )
+        else:
+            parent = os.path.dirname(directory)
+            if os.path.exists(parent) and not os.access(parent, os.W_OK):
+                errors.append(
+                    Error(
+                        f"The Django server process does not have write permissions to '{parent}' to create '{directory}'.",
+                        hint=f"Check folder permissions. You may need to run `sudo chown -R www-data:www-data {media_root}`.",
+                        id='qatrack.E001',
+                    )
+                )
+
+    return errors

--- a/qatrack/qatrack_core/checks.py
+++ b/qatrack/qatrack_core/checks.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from pathlib import Path
 
 from django.conf import settings
 from django.core.checks import Error, register
@@ -10,21 +11,30 @@ def check_media_folder_permissions(app_configs, **kwargs):
     errors = []
     media_root = getattr(settings, 'MEDIA_ROOT', None)
     
+    # Check if MEDIA_ROOT is configured and if the directory exists
+    # This check is very likely unnecessary, since Django appears to recreate the folder on manage.py check, but it is here for completeness.
+
     if not media_root:
+        errors.append(Error("The Media folder is not configured"))
         return errors
         
-    if not os.path.exists(media_root):
+    media_root_path = Path(media_root)
+
+    if not media_root_path.exists():
+        errors.append(Error(f"The Media folder '{media_root}' does not exist"))
         return errors
-        
+    # End of redundant check    
+    
     uploads_dirs = [
-        media_root,
-        os.path.join(media_root, 'uploads'),
-        os.path.join(media_root, 'uploads', 'tmp'),
+        media_root_path,
+        media_root_path / 'uploads',
+        media_root_path / 'uploads' / 'tmp',
     ]
     
+
     for directory in uploads_dirs:
-        if os.path.exists(directory):
-            if not os.access(directory, os.W_OK):
+        if directory.exists():
+            if not directory.is_dir() or not os.access(directory, os.W_OK):
                 errors.append(
                     Error(
                         f"The Django server process does not have write permissions to '{directory}'.",
@@ -34,9 +44,9 @@ def check_media_folder_permissions(app_configs, **kwargs):
                 )
             else:
                 try:
-                    fd, temp_path = tempfile.mkstemp(dir=directory)
+                    fd, temp_path = tempfile.mkstemp(dir=str(directory))
                     os.close(fd)
-                    os.remove(temp_path)
+                    Path(temp_path).unlink()
                 except Exception as e:
                     errors.append(
                         Error(
@@ -46,8 +56,8 @@ def check_media_folder_permissions(app_configs, **kwargs):
                         )
                     )
         else:
-            parent = os.path.dirname(directory)
-            if os.path.exists(parent) and not os.access(parent, os.W_OK):
+            parent = directory.parent
+            if parent.exists() and not os.access(parent, os.W_OK):
                 errors.append(
                     Error(
                         f"The Django server process does not have write permissions to '{parent}' to create '{directory}'.",
@@ -55,5 +65,4 @@ def check_media_folder_permissions(app_configs, **kwargs):
                         id='qatrack.E001',
                     )
                 )
-
     return errors

--- a/qatrack/settings.py
+++ b/qatrack/settings.py
@@ -7,6 +7,7 @@
 
 import datetime
 import os
+import pathlib
 import sys
 
 import matplotlib
@@ -711,7 +712,8 @@ if use_docker:
     except OSError:
         import secrets
         SECRET_KEY = secrets.token_urlsafe(64)
-        os.makedirs(os.path.dirname(SECRET_FILEPATH), exist_ok=True)
+        if not os.path.isdir(os.path.dirname(SECRET_FILEPATH)):
+            os.makedirs(os.path.dirname(SECRET_FILEPATH), exist_ok=True)
         with open(SECRET_FILEPATH, 'w') as f:
             f.write(SECRET_KEY)
 
@@ -747,9 +749,21 @@ UPLOAD_ROOT = os.path.join(MEDIA_ROOT, "uploads")
 TMP_UPLOAD_ROOT = os.path.join(UPLOAD_ROOT, "tmp")
 TMP_REPORT_ROOT = os.path.join(MEDIA_ROOT, "reports")
 
-for d in (MEDIA_ROOT, UPLOAD_ROOT, TMP_UPLOAD_ROOT, LOG_ROOT, TMP_REPORT_ROOT):
-    if not os.path.isdir(d):
-        os.mkdir(d)
+# region: pathlib recreation of path checks and creation.  
+# This is to avoid issues with os.path.exists() returning False for symlinks to directories
+# os.path variables are left in place for backwards compatibility with other code that may use them
+MEDIA_ROOT_PATH = pathlib.Path(MEDIA_ROOT)
+UPLOAD_ROOT_PATH = pathlib.Path(UPLOAD_ROOT)
+TMP_UPLOAD_ROOT_PATH = pathlib.Path(TMP_UPLOAD_ROOT)
+TMP_REPORT_ROOT_PATH = pathlib.Path(TMP_REPORT_ROOT)
+LOG_ROOT_PATH = pathlib.Path(LOG_ROOT)
+TMP_REPORT_ROOT_PATH = pathlib.Path(TMP_REPORT_ROOT)
+
+for d in (MEDIA_ROOT_PATH, UPLOAD_ROOT_PATH, TMP_UPLOAD_ROOT_PATH, LOG_ROOT_PATH, TMP_REPORT_ROOT_PATH):
+    if not d.exists() and not d.is_dir():
+        d.mkdir(parents=True, exist_ok=True)
+# endregion
+
 
 CACHE_LOCATION = os.path.join(PROJECT_ROOT, "cache", "cache_data")
 IS_FILE_CACHE = CACHES['default']['BACKEND'] == 'django.core.cache.backends.filebased.FileBasedCache'


### PR DESCRIPTION
## Summary

It's possible to have invalid write access in an install, causing attachments to fail as the server fails to write to /media. Added a check that triggers during `uv run python manage.py migrate` to verify the permissions and test by saving a file to that folder.

No documentation changes needed:
```
ERRORS:
?: (qatrack.E001) The Django server process does not have write permissions to '/home/<user>/web/qatrackplus/qatrack/media'.
        HINT: Check folder permissions. You may need to run `sudo chown -R www-data:www-data /home/<user>/web/qatrackplus/qatrack/media` and `sudo chmod -R 775 /home/<user>/web/qatrackplus/qatrack/media` (replace www-data with your web server user).
?: (qatrack.E001) The Django server process does not have write permissions to '/home/<user>/web/qatrackplus/qatrack/media/uploads'.
        HINT: Check folder permissions. You may need to run `sudo chown -R www-data:www-data /home/<user>/web/qatrackplus/qatrack/media` and `sudo chmod -R 775 /home/<user>/web/qatrackplus/qatrack/media` (replace www-data with your web server user).
?: (qatrack.E001) The Django server process does not have write permissions to '/home/<user>/web/qatrackplus/qatrack/media/uploads/tmp'.
        HINT: Check folder permissions. You may need to run `sudo chown -R www-data:www-data /home/<user>/web/qatrackplus/qatrack/media` and `sudo chmod -R 775 /home/<user>/web/qatrackplus/qatrack/media` (replace www-data with your web server user).

```

## Related Issues

Closes #803 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Modernization / migration (part of the qatrackplus modernization effort)
- [ ] Documentation only
- [ ] Refactor / chore (no functional change)

## Target Branch

Dev

## AI Usage Disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used:
  - **Tools / where used:** _e.g. GitHub Copilot for boilerplate_
  - [x] I've reviewed every AI-generated line as if I wrote it myself, and confirm: no PHI shared, no license-incompatible content (Apache-2.0).
---

## PR Procedure

### Coder Tasks

- [x] Rebased / merged `Dev` branch; no merge conflicts.
- [x] `uv run pre-commit run --all-files` passes (ruff lint, ruff-format, django-upgrade).
  - `uv run ruff check . --fix` to help resolve linting errors 
- [x] Django migrations generated and committed if models changed.
- [x] `uv run python -Wd manage.py check` reviewed for new deprecation warnings.
- [x] `uv run pytest` full test suite passes.
- [x] Docker builds succeed if touched.
- [x] Docs updated under `docs/` if behaviour, settings, or APIs changed.
- [x] `release_notes.md` updated if user-facing.
- [x] No secrets, debug code, or stray `print`/`console.log` left in.

### Review Code

- [x] Reviewer verifies the target branch.
- [ ] For non-trivial changes: pulled the branch, ran it locally, and confirmed it works as described.
- [x] CI is green; test suite and `pre-commit` pass.
- [x] Reads through all changed files for anything weird or unintended.
- [x] Logic is correct; edge cases and error handling considered.
- [ ] Migrations are sane and reversible where possible.
- [x] Changes are consistent with the modernization direction (no reintroduction
      of patterns being migrated away from, e.g. flake8/yapf-era conventions).
- [x] No security concerns (input validation, permissions, injection, XSS).
- [x] Comments are sufficient and not overkill.
- [x] Typos, spellcheck, professional.
- [x] Reviewer sends back review.

### Edits

- [ ] Coder fixes any issues.
- [x] Reviewer approves.

> Maintainer review is required for breaking changes, new features, and migrations.
> For bug fixes, refactors, and docs-only changes, reviewer approval is sufficient to merge.

---

## Testing Notes

Discovered fault while writing another feature and fix the issue. Created this branch for this specific issue, reversed our fixes and confirmed it did detect the issue. 

` uv run python manage.py check ` and `uv run python manage.py migrate` properly showed the errors. Reapplied the fix, those errors went away.

## Screenshots

N/A
