### PR TITLE
fix: use unversioned qatrackplus database name in deploy config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       postgres:
         image: postgres@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e
         env:
-          POSTGRES_DB: qatrackplus40
+          POSTGRES_DB: qatrackplus
           POSTGRES_USER: qatrack
           POSTGRES_PASSWORD: qatrackpass
         ports:
@@ -134,7 +134,7 @@ jobs:
           cp deploy/mysql/local_settings.py qatrack/local_settings.py
           sed -i "s/'HOST': ''/'HOST': '127.0.0.1'/g" qatrack/local_settings.py
           # Setup mysql users and privileges for MySQL 8 compat
-          docker exec -i ${{ job.services.mysql.id }} mysql -u root -proot -e "CREATE USER 'qatrack'@'%' IDENTIFIED WITH mysql_native_password BY 'qatrackpass'; CREATE USER 'qatrack_reports'@'%' IDENTIFIED WITH mysql_native_password BY 'qatrackpass'; CREATE DATABASE qatrackplus40 CHARACTER SET utf8mb4; GRANT ALL ON qatrackplus40.* TO 'qatrack'@'%'; GRANT ALL ON test_qatrackplus40.* TO 'qatrack'@'%'; GRANT SELECT ON qatrackplus40.* TO 'qatrack_reports'@'%'; FLUSH PRIVILEGES;"
+          docker exec -i ${{ job.services.mysql.id }} mysql -u root -proot -e "CREATE USER 'qatrack'@'%' IDENTIFIED WITH mysql_native_password BY 'qatrackpass'; CREATE USER 'qatrack_reports'@'%' IDENTIFIED WITH mysql_native_password BY 'qatrackpass'; CREATE DATABASE qatrackplus CHARACTER SET utf8mb4; GRANT ALL ON qatrackplus.* TO 'qatrack'@'%'; GRANT ALL ON test_qatrackplus.* TO 'qatrack'@'%'; GRANT SELECT ON qatrackplus.* TO 'qatrack_reports'@'%'; FLUSH PRIVILEGES;"
           docker exec -i ${{ job.services.mysql.id }} sh -c "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root -proot mysql"
 
       - name: Run Tests
@@ -176,7 +176,7 @@ jobs:
         if: matrix.db == 'mssql'
         uses: Particular/install-sql-server-action@669fc7147c13cb314685bab823a55a5e22a0c95f
         with:
-          catalog: qatrackplus40
+          catalog: qatrackplus
           connection-string-env-var: SQL_CONNECTION_STRING
 
       - name: Configure MSSQL local_settings.py
@@ -188,7 +188,7 @@ jobs:
           parts = dict(part.split('=', 1) for part in conn_str.split(';') if '=' in part)
           db_settings = {
               'ENGINE': 'mssql',
-              'NAME': parts.get('Database', parts.get('Initial Catalog', 'qatrackplus40')),
+              'NAME': parts.get('Database', parts.get('Initial Catalog', 'qatrackplus')),
               'HOST': parts.get('Server', parts.get('Data Source', r'localhost\SQLEXPRESS')),
               'PORT': '',
               'OPTIONS': {

--- a/deploy/mysql/create_db_and_role.sql
+++ b/deploy/mysql/create_db_and_role.sql
@@ -1,5 +1,5 @@
 CREATE USER 'qatrack'@'localhost' IDENTIFIED BY 'qatrackpass';
-CREATE DATABASE qatrackplus40 CHARACTER SET utf8mb4;
-GRANT ALL ON qatrackplus40.* TO 'qatrack'@'localhost';
+CREATE DATABASE qatrackplus CHARACTER SET utf8mb4;
+GRANT ALL ON qatrackplus.* TO 'qatrack'@'localhost';
 flush privileges;
 

--- a/deploy/mysql/create_ro_role.sql
+++ b/deploy/mysql/create_ro_role.sql
@@ -1,2 +1,2 @@
 CREATE USER 'qatrack_reports'@'localhost' IDENTIFIED BY 'qatrackpass';
-GRANT SELECT ON qatrackplus40.* to 'qatrack_reports'@'localhost';
+GRANT SELECT ON qatrackplus.* to 'qatrack_reports'@'localhost';

--- a/deploy/mysql/generate_ro_privileges.sql
+++ b/deploy/mysql/generate_ro_privileges.sql
@@ -4,7 +4,7 @@ SELECT
     CONCAT('GRANT SELECT ON ', table_name, ' TO qatrack_reports@localhost;')
 FROM information_schema.tables
 WHERE
-    table_schema = 'qatrackplus40'
+    table_schema = 'qatrackplus'
 AND
     table_name not in ('django_session', 'auth_user', 'authtoken_token');
 SELECT 'GRANT SELECT (id, last_login, is_superuser, username, first_name, last_name, email, is_staff, is_active, date_joined) ON auth_user TO qatrack_reports@localhost;';

--- a/deploy/mysql/local_settings.py
+++ b/deploy/mysql/local_settings.py
@@ -4,7 +4,7 @@ DEBUG = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'qatrackplus40',
+        'NAME': 'qatrackplus',
         'USER': 'qatrack',
         'PASSWORD': 'qatrackpass',
         'HOST': '',  # Set to empty string for localhost. Not used with sqlite3.
@@ -12,7 +12,7 @@ DATABASES = {
     },
     'readonly': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'qatrackplus40',
+        'NAME': 'qatrackplus',
         'USER': 'qatrack_reports',
         'PASSWORD': 'qatrackpass',
         'HOST': '',  # Set to empty string for localhost. Not used with sqlite3.

--- a/deploy/postgres/create_db_and_role.sql
+++ b/deploy/postgres/create_db_and_role.sql
@@ -1,3 +1,3 @@
 CREATE USER qatrack WITH PASSWORD 'qatrackpass';
-CREATE DATABASE qatrackplus40 OWNER qatrack;
-GRANT ALL PRIVILEGES ON DATABASE qatrackplus40 to qatrack;
+CREATE DATABASE qatrackplus OWNER qatrack;
+GRANT ALL PRIVILEGES ON DATABASE qatrackplus to qatrack;

--- a/deploy/postgres/grant_ro_rights.sql
+++ b/deploy/postgres/grant_ro_rights.sql
@@ -1,5 +1,5 @@
-GRANT CONNECT ON DATABASE qatrackplus40 TO qatrack_reports;
-\c qatrackplus40
+GRANT CONNECT ON DATABASE qatrackplus TO qatrack_reports;
+\c qatrackplus
 GRANT USAGE ON SCHEMA public TO qatrack_reports;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO qatrack_reports;
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO qatrack_reports;

--- a/deploy/postgres/local_settings.py
+++ b/deploy/postgres/local_settings.py
@@ -4,7 +4,7 @@ DEBUG = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'qatrackplus40',
+        'NAME': 'qatrackplus',
         'USER': 'qatrack',
         'PASSWORD': 'qatrackpass',
         'HOST': '127.0.0.1',  # Set to 127.0.0.1 for localhost. Not used with sqlite3.
@@ -12,7 +12,7 @@ DATABASES = {
     },
     'readonly': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'qatrackplus40',
+        'NAME': 'qatrackplus',
         'USER': 'qatrack_reports',
         'PASSWORD': 'qatrackpass',
         'HOST': '127.0.0.1',  # Set to 127.0.0.1 for localhost. Not used with sqlite3.

--- a/deploy/sqlite/local_settings.py
+++ b/deploy/sqlite/local_settings.py
@@ -4,7 +4,7 @@ DEBUG = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql', 'mysql', 'sqlite3'
-        'NAME': 'qatrackplus40',  # Or path to database file if using sqlite3.
+        'NAME': 'qatrackplus',  # Or path to database file if using sqlite3.
         'USER': '',  # Not used with sqlite3.
         'PASSWORD': '',  # Not used with sqlite3.
         'HOST': '',  # Set to empty string for localhost. Not used with sqlite3.
@@ -12,7 +12,7 @@ DATABASES = {
     },
     'readonly': {
         'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql', 'mysql', 'sqlite3'
-        'NAME': 'qatrackplus40',  # Or path to database file if using sqlite3.
+        'NAME': 'qatrackplus',  # Or path to database file if using sqlite3.
         'USER': '',  # Not used with sqlite3.
         'PASSWORD': '',  # Not used with sqlite3.
         'HOST': '',  # Set to empty string for localhost. Not used with sqlite3.

--- a/docs/install/linux.rst
+++ b/docs/install/linux.rst
@@ -112,7 +112,7 @@ PostgreSQL locally. Run the following commands:
     sudo apt-get install postgresql libpq-dev postgresql-client postgresql-client-common
 
 After that completes, we can create a new database and Postgres user (db
-name/user/pwd = qatrackplus40/qatrack/qatrackpass) as follows:
+name/user/pwd = qatrackplus/qatrack/qatrackpass) as follows:
 
 .. code-block:: bash
 
@@ -177,7 +177,7 @@ and restart the pg server:
 
 
     Now we can create and configure a user (db name/user/pwd =
-    qatrackplus40/qatrack/qatrackpass) and database for QATrack+:
+    qatrackplus/qatrack/qatrackpass) and database for QATrack+:
 
     .. code-block:: bash
 
@@ -325,7 +325,7 @@ required).
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'qatrackplus40',
+            'NAME': 'qatrackplus',
             'USER': 'qatrack',
             'PASSWORD': 'qatrackpass',
             'HOST': '127.0.0.1',
@@ -333,7 +333,7 @@ required).
         },
         'readonly': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'qatrackplus40',
+            'NAME': 'qatrackplus',
             'USER': 'qatrack_reports',
             'PASSWORD': 'qatrackpass',
             'HOST': '127.0.0.1',
@@ -389,11 +389,11 @@ follows:
 
         # or MySQL if you set a password during install
         sudo mysql -u root -p -N -B -e "$(cat deploy/mysql/generate_ro_privileges.sql)" > grant_ro_privileges.sql
-        sudo mysql -u root -p --database qatrackplus40 < grant_ro_privileges.sql
+        sudo mysql -u root -p --database qatrackplus < grant_ro_privileges.sql
 
         # or MySQL if you did not set a password during install
         sudo mysql -N -B -e "$(cat deploy/mysql/generate_ro_privileges.sql)" > grant_ro_privileges.sql
-        sudo mysql --database qatrackplus40 < grant_ro_privileges.sql
+        sudo mysql --database qatrackplus < grant_ro_privileges.sql
 
 
 You also need to create a super user so you can login and begin configuring


### PR DESCRIPTION
## Summary

The deploy config templates and database bootstrap scripts now use the canonical `qatrackplus` database name instead of the version-pinned `qatrackplus40`, matching what the install docs already tell users to create.

## Why this matters

Issue #811 (filed by @nsmela) points out that `deploy/postgres/local_settings.py` hard-codes `qatrackplus40`, and a follow-up notes the SQL scripts do too. Meanwhile `docs/install/config.rst` and `docs/install/win.rst` already use `qatrackplus`, so a user following those docs creates a database named `qatrackplus` but the shipped `local_settings.py` points at `qatrackplus40`, and the connection fails. The instruction on the issue is simply to "remove the `40`".

## Changes

Renamed `qatrackplus40` to `qatrackplus` everywhere it still appeared (`grep -r qatrackplus40` now returns nothing):

- `deploy/{postgres,mysql,sqlite}/local_settings.py` and the SQL bootstrap scripts (`create_db_and_role.sql`, `grant_ro_rights.sql`, `create_ro_role.sql`, `generate_ro_privileges.sql`).
- `.github/workflows/ci.yml`, in lockstep, since it provisions the test databases to match these settings files. The Postgres `POSTGRES_DB`, the MySQL `CREATE DATABASE`/`GRANT` statements (including the `test_qatrackplus` database Django creates for the test run), and the SQL Server catalog all move to the unversioned name so the existing pytest matrix keeps passing.
- `docs/install/linux.rst`, the only doc still using the versioned name, so the Linux install path matches the shipped defaults.

This is a rename of the example/default database name for fresh installs; existing deployments are unaffected (no data migration is implied by editing these templates).

## Testing

`grep -r qatrackplus40` returns no matches. The change is verified end to end by the existing Postgres and MySQL CI legs, which provision `qatrackplus`/`test_qatrackplus` from the renamed `ci.yml` and run the test suite against them.

Closes #811
