### PR TITLE
Fix/csrf token for docker config

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -6,3 +6,9 @@ USE_DOCKER=true
 # Add the hostname or IP address you will use to access QATrack+ here.
 # For example: ALLOWED_HOSTS=localhost,127.0.0.1
 ALLOWED_HOSTS=*
+
+# Required for Django 4.0+ or logins/forms behind a reverse proxy will fail
+# with "CSRF verification failed". Must include the scheme (http/https).
+# If left unset, it's derived from ALLOWED_HOSTS above (both schemes, "*" skipped).
+# For example: CSRF_TRUSTED_ORIGINS=https://my-server,http://my-server
+# CSRF_TRUSTED_ORIGINS=

--- a/qatrack/settings.py
+++ b/qatrack/settings.py
@@ -706,6 +706,17 @@ use_docker = os.environ.get('USE_DOCKER', '').strip().lower() in {'1', 'true', '
 if use_docker:
     ALLOWED_HOSTS = [h.strip() for h in os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',') if h.strip()]
 
+    _csrf_trusted_env = os.environ.get('CSRF_TRUSTED_ORIGINS', '').strip()
+    if _csrf_trusted_env:
+        CSRF_TRUSTED_ORIGINS = [o.strip() for o in _csrf_trusted_env.split(',') if o.strip()]
+    else:
+        CSRF_TRUSTED_ORIGINS = [
+            scheme + host
+            for host in ALLOWED_HOSTS
+            for scheme in ('http://', 'https://')
+            if host != '*'
+        ]
+    
     SECRET_FILEPATH = os.path.join(PROJECT_ROOT, '..', 'deploy', 'docker', 'user-data', 'secret_key.txt')
     try:
         with open(SECRET_FILEPATH) as f:


### PR DESCRIPTION
## Summary

CSRF_TRUSTED_ORIGINS must be set for any request whose Origin/Referer host differs from the one Django computed, otherwise POSTs fail with "CSRF verification failed. Origin checking failed". The Docker deployment (USE_DOCKER=true) sets ALLOWED_HOSTS from the environment but never sets CSRF_TRUSTED_ORIGINS (it's present in local_settings.py for other setups), so submitting any form is broken out of the box on a non-localhost hostname.

If CSRF_TRUSTED_ORIGINS is not configured, it falls back to building origins from ALLOWED_HOSTS.

No change for non-Docker deployments.

## Related Issues

None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature ( adds functionality, always assumed to be breaking until tested by maintainers)
- [ ] Breaking change (fix or addition that changes existing behaviour)
- [ ] Documentation only

## Target Branch

 develop 


## AI Usage Disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used:
  - **Tools / where used:**: Claude (Anthropic) - reviewed CSRF requirement, drafted the settings snippet, parts of this description.
  - [x] I've reviewed every AI-generated line as if I wrote it myself, and confirm: no PHI shared, no license-incompatible content (Apache-2.0).

---

## PR Procedure

### Coder Tasks

- [x] Rebased / merged `develop` branch; no merge conflicts.
- [x] `uv run pre-commit run --all-files` passes (ruff lint, ruff-format, django-upgrade).
  - `uv run ruff check . --fix` to help resolve linting errors
- [x] `uv run python -Wd manage.py check` reviewed for new deprecation warnings.
- [x] `uv run pytest` full test suite passes.
- [x] `uv run python manage.py makemigrations --check --dry-run` if migrations are found, change should be marked Breaking
- [x] Docker builds succeed if touched.
- [ deprecated ] Docs updated under `docs/` if behaviour, settings, or APIs changed.
- [x] `release_notes.md` updated if user-facing.
- [x] No secrets, debug code, or stray `print`/`console.log` left in.

### Review Code

- [x] Reviewer verifies the target branch.
- [x] For non-trivial changes: pulled the branch, ran it locally, and confirmed it works as described.
- [x] CI is green; test suite and `pre-commit` pass.
- [x] Reads through all changed files for anything weird or unintended.
- [x] Logic is correct; edge cases and error handling considered.
- [x] Migrations are sane and reversible where possible.
- [x] Changes are consistent with the modernization direction (no reintroduction
      of patterns being migrated away from, e.g. flake8/yapf-era conventions).
- [x] No security concerns (input validation, permissions, injection, XSS).
- [x] Comments are sufficient and not overkill.
- [x] Typos, spellcheck, professional.
- [x] Reviewer sends back review.

### Edits

- [ ] Coder fixes any issues.
- [ ] Reviewer approves.

> Maintainer review is required for breaking changes, new features, and migrations.
> For bug fixes, refactors, and docs-only changes, reviewer approval is sufficient to merge.

---

## Testing Notes

Tested via Docker (docker compose up, USE_DOCKER=true) with the bundled nginx service:

Before: with ALLOWED_HOSTS=my-server and no CSRF_TRUSTED_ORIGINS, logging in at https://my-server:8080 returns 403 "CSRF verification failed".
After : CSRF_TRUSTED_ORIGINS=https://my-server in .env , forms submit over TLS.


## Screenshots
N/A.
