### PR TITLE
Update backup script to use environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,32 @@ jobs:
             exit 1
           fi
 
+      - name: Verify backup produces a valid dump
+        working-directory: deploy/docker
+        run: |
+          set -euo pipefail
+          docker compose -f compose.yaml exec -T backup sh -eu -c '
+            rm -f /backups/db_*.dump /backups/media_*.tar.gz 2>/dev/null || true
+
+            # Run the backup exactly as the nightly cron job does.
+            bash /backup.sh
+
+            dump=$(ls -1t /backups/db_*.dump 2>/dev/null | head -1 || true)
+            [ -n "$dump" ] || { echo "FAIL: no db dump produced"; exit 1; }
+
+            size=$(stat -c %s "$dump")
+            echo "dump=$dump size=$size"
+            [ "$size" -gt 0 ] || { echo "FAIL: db dump is 0 bytes (auth failed)"; exit 1; }
+
+            # Prove it is a real pg_dump archive, not just non-empty.
+            pg_restore --list "$dump" >/dev/null || { echo "FAIL: not a valid archive"; exit 1; }
+
+            # Media archive must also be produced.
+            ls -1 /backups/media_*.tar.gz >/dev/null || { echo "FAIL: media archive missing"; exit 1; }
+
+            echo "PASS: valid db dump + media archive produced"
+          '
+
       - name: Tear Down
         if: always()
         working-directory: deploy/docker

--- a/deploy/docker/backup/backup.sh
+++ b/deploy/docker/backup/backup.sh
@@ -11,7 +11,8 @@ RETENTION_DAYS=7
 echo "Starting backup at $DATE"
 
 # Dump database
-pg_dump -h postgres -U postgres -d qatrackplus -F c -f "$BACKUP_DIR/db_$DATE.dump"
+export PGPASSWORD="$POSTGRES_PASSWORD"
+pg_dump -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -F c -f "$BACKUP_DIR/db_$DATE.dump"
 
 # Tar media
 tar -czf "$BACKUP_DIR/media_$DATE.tar.gz" -C / media/


### PR DESCRIPTION
## Summary

Nightly backups were silently failing: `pg_dump` was hardcoded to user `postgres`/db `qatrackplus` with no password, so it failed auth immediately. Fixed by using `$POSTGRES_USER`/`$POSTGRES_DB`/`$POSTGRES_PASSWORD` (already available via `env_file: .env`) and exporting `PGPASSWORD` for `pg_dump`.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature ( adds functionality, always assumed to be breaking until tested by maintainers)
- [ ] Breaking change (fix or addition that changes existing behaviour)
- [ ] Documentation only

## Target Branch

develop

## AI Usage Disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used:
  - **Tools / where used:** Claude Code — diagnosed the failing backup and wrote the `backup.sh` fix.
  - [x] I've reviewed every AI-generated line as if I wrote it myself, and confirm: no PHI shared, no license-incompatible content (Apache-2.0).

---

## PR Procedure

### Coder Tasks

- [x] Rebased / merged `develop` branch; no merge conflicts.
- [x] `uv run pre-commit run --all-files` passes (ruff lint, ruff-format, django-upgrade).
  - `uv run ruff check . --fix` to help resolve linting errors
- [x] `uv run python -Wd manage.py check` reviewed for new deprecation warnings.
- [x] `uv run pytest` full test suite passes.
- [x] `uv run python manage.py makemigrations --check --dry-run` if migrations are found, change should be marked Breaking
- [x] Docker builds succeed if touched.
- [x] Docs updated under `docs/` if behaviour, settings, or APIs changed.
- [x] `release_notes.md` updated if user-facing.
- [x] No secrets, debug code, or stray `print`/`console.log` left in.

### Review Code

- [x] Reviewer verifies the target branch.
- [x] For non-trivial changes: pulled the branch, ran it locally, and confirmed it works as described.
- [x] CI is green; test suite and `pre-commit` pass.
- [x] Reads through all changed files for anything weird or unintended.
- [x] Logic is correct; edge cases and error handling considered.
- [x] Migrations are sane and reversible where possible.
- [x] Changes are consistent with the modernization direction (no reintroduction
      of patterns being migrated away from, e.g. flake8/yapf-era conventions).
- [x] No security concerns (input validation, permissions, injection, XSS).
- [x] Comments are sufficient and not overkill.
- [x] Typos, spellcheck, professional.
- [x] Reviewer sends back review.

### Edits

- [ ] Coder fixes any issues.
- [ ] Reviewer approves.

> Maintainer review is required for breaking changes, new features, and migrations.
> For bug fixes, refactors, and docs-only changes, reviewer approval is sufficient to merge.

---

## Testing Notes

Rebuilt the `backup` container (`docker compose up -d --build backup`) and ran `bash /backup.sh` manually inside it. Confirmed `db_*.dump` and `media_*.tar.gz` were both produced with real content, vs. the previous 0-byte dump and missing media archive.

## Screenshots

N/A