### PR TITLE
Fix(reports): resolve ReportSchedule str attribute error and template interpolation (#837)

### DIFF
--- a/qatrack/qa/templates/qa/charts.html
+++ b/qatrack/qa/templates/qa/charts.html
@@ -3,8 +3,19 @@
 {% load i18n %}
 
 {% block extra_head %}
+<script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 <script type="text/javascript">
-  window.pgettext = function(context, string){ return string;};
+  if (!window.interpolate) {
+    window.interpolate = function(fmt, d, named) {
+      if (named) {
+        return fmt.replace(/%\(\w+\)s/g, function(match) { return String(d[match.slice(2, -2)]) });
+      }
+      return fmt.replace(/%s/g, function(match) { return String(d.shift()) });
+    };
+  }
+  if (!window.pgettext) {
+    window.pgettext = function(context, string) { return string; };
+  }
 </script>
 <script type="text/javascript" src="{% static "recurrence/js/recurrence.js" %}"></script>
 <script type="text/javascript" src="{% static "recurrence/js/recurrence-widget.js" %}"></script>

--- a/qatrack/qatrack_core/tests/test_django_q2.py
+++ b/qatrack/qatrack_core/tests/test_django_q2.py
@@ -99,6 +99,31 @@ class TestDjangoQ2Integration(TestCase):
         # Verify it executed without errors (logs something)
         mock_logger.info.assert_called()
 
+    @patch('qatrack.qatrack_core.tasks.logger')
+    def test_run_periodic_scheduler_midnight_crossing(self, mock_logger):
+        """Test that run_periodic_scheduler detects items scheduled at 00:00 when running before midnight"""
+        from qatrack.notifications.models import QCSchedulingNotice, RecipientGroup
+
+        recipients = RecipientGroup.objects.create(name="Midnight Group")
+        notice = QCSchedulingNotice.objects.create(
+            recipients=recipients,
+            notification_type=QCSchedulingNotice.DUE,
+            time="00:00",
+            recurrences="RRULE:FREQ=DAILY"
+        )
+
+        scheduled_items = []
+        def handler(instance, send_time):
+            scheduled_items.append((instance, send_time))
+
+        fake_now = timezone.localtime(timezone.now()).replace(hour=23, minute=55, second=0, microsecond=0)
+        with patch('qatrack.qatrack_core.tasks.timezone.localtime', return_value=fake_now), \
+             patch('qatrack.qatrack_core.utils.timezone.localtime', return_value=fake_now):
+            run_periodic_scheduler(QCSchedulingNotice, "test_midnight", handler, time_field="time", recurrence_field="recurrences")
+
+        self.assertGreater(len(scheduled_items), 0)
+        self.assertTrue(any(item[0].id == notice.id for item in scheduled_items))
+
     def test_notification_scheduling(self):
         """Test that notification schedules are created correctly"""
         from qatrack.notifications.models import QCSchedulingNotice, RecipientGroup

--- a/qatrack/reports/models.py
+++ b/qatrack/reports/models.py
@@ -140,12 +140,10 @@ class ReportNote(models.Model):
         verbose_name_plural = _l("Report Notes")
 
     def __str__(self):
-        return "#%d. %s - %s - %s" % (
-            self.pk,
-            self.report.title,
-            self.schedule.rrule.to_text(),
-            self.time,
-        )
+        report_title = self.report.title if hasattr(self, "report") and self.report else ""
+        if self.pk:
+            return "#%d. %s - %s" % (self.pk, report_title, self.heading)
+        return "%s - %s" % (report_title, self.heading)
 
 
 class ReportSchedule(RecurrenceFieldMixin, models.Model):
@@ -219,12 +217,16 @@ class ReportSchedule(RecurrenceFieldMixin, models.Model):
         verbose_name_plural = _l("Report Schedules")
 
     def __str__(self):
-        return "#%d. %s - %s - %s" % (
-            self.pk,
-            self.report.title,
-            self.schedule.rrule.to_text(),
-            self.time,
-        )
+        if self.time is None:
+            time_str = ""
+        elif hasattr(self.time, "strftime"):
+            time_str = self.time.strftime("%H:%M")
+        else:
+            time_str = str(self.time)[:5]
+        report_title = self.report.title if hasattr(self, "report") and self.report else ""
+        if self.pk:
+            return "#%d. %s @ %s" % (self.pk, report_title, time_str)
+        return "%s @ %s" % (report_title, time_str)
 
     def recipients(self):
         """Gather recipients that are supposed to recieve this report"""

--- a/qatrack/reports/templates/reports/reports.html
+++ b/qatrack/reports/templates/reports/reports.html
@@ -8,8 +8,19 @@
 {% block head_title %}{% trans "Reports" %}{% endblock %}
 
 {% block extra_head %}
+<script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 <script type="text/javascript">
-  window.pgettext = function(context, string){ return string;};
+  if (!window.interpolate) {
+    window.interpolate = function(fmt, d, named) {
+      if (named) {
+        return fmt.replace(/%\(\w+\)s/g, function(match) { return String(d[match.slice(2, -2)]) });
+      }
+      return fmt.replace(/%s/g, function(match) { return String(d.shift()) });
+    };
+  }
+  if (!window.pgettext) {
+    window.pgettext = function(context, string) { return string; };
+  }
 </script>
 <script type="text/javascript" src="{% static "recurrence/js/recurrence.js" %}"></script>
 <script type="text/javascript" src="{% static "recurrence/js/recurrence-widget.js" %}"></script>

--- a/qatrack/reports/tests/test_base.py
+++ b/qatrack/reports/tests/test_base.py
@@ -1129,6 +1129,28 @@ class TestReportModels(TestCase):
     def test_savedreport_str(self):
         assert str(self.report) == "#%d. title - Test List Instance Summary - PDF" % self.report.pk
 
+    def test_reportschedule_str(self):
+        schedule = models.ReportSchedule.objects.create(
+            report=self.report,
+            time="00:00",
+            schedule="RRULE:FREQ=DAILY",
+            created_by=self.user,
+            modified_by=self.user,
+        )
+        assert str(schedule) == "#%d. %s @ 00:00" % (schedule.pk, self.report.title)
+
+    def test_reportnote_str(self):
+        note = models.ReportNote.objects.create(
+            report=self.report,
+            heading="Test Heading",
+            content="Test Content",
+        )
+        assert str(note) == "#%d. %s - %s" % (note.pk, self.report.title, note.heading)
+
+    def test_javascript_catalog_url(self):
+        from django.urls import reverse
+        assert reverse("javascript-catalog") == "/jsi18n/"
+
 
 class TestReportTasks(TestCase):
 


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR resolves several interrelated issues affecting report scheduling and recurrence rule configuration:

1. **Fix `AttributeError: 'Recurrence' object has no attribute 'rrule'` in `ReportSchedule.__str__`**:
   - In `django-recurrence`, `Recurrence` objects expose `.rrules` (a list of `Rule` objects) rather than a singular `.rrule` property, and `Rule` does not provide a `.to_text()` method. This caused unhandled `AttributeError` exceptions when loading the Django admin change view at `/admin/reports/reportschedule/<id>/change/`.
   - Updated `ReportSchedule.__str__` to format `#<id>. <report_title> @ <time>`, safely handling both `datetime.time` objects and string inputs.
   - Fixed a similar copy-paste issue in `ReportNote.__str__` where it attempted to access non-existent `self.schedule` and `self.time`.

2. **Fix missing dynamic recurrence text in scheduling modal**:
   - The django-recurrence widget relies on `window.interpolate` and `window.pgettext` to format dynamic rule descriptions (e.g., *"weekly, on Mondays"*).
   - Loaded `{% url 'javascript-catalog' %}` in [`reports.html`](file:///c:/Users/nsmel/source/repos/qatrackplus/qatrack/reports/templates/reports/reports.html) and [`charts.html`](file:///c:/Users/nsmel/source/repos/qatrackplus/qatrack/qa/templates/qa/charts.html), and provided safe fallback definitions for `window.interpolate` and `window.pgettext` to prevent JavaScript reference errors.

3. **Scheduler Midnight Boundary Test**:
   - Added a unit test in [`test_django_q2.py`](file:///c:/Users/nsmel/source/repos/qatrackplus/qatrack/qatrack_core/tests/test_django_q2.py) verifying `run_periodic_scheduler` properly evaluates and schedules notices set for midnight (`00:00`) when the execution window spans across midnight (e.g., 23:55 to 00:10).

## Related Issues

Closes #837

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature ( adds functionality, always assumed to be breaking until tested by maintainers)
- [ ] Breaking change (fix or addition that changes existing behaviour)
- [ ] Documentation only

## Target Branch

`develop`

## AI Usage Disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used:
  - **Tools / where used:** Antigravity AI coding assistant for investigating `django-recurrence` model internals, adding `jsi18n` catalog fallbacks, and writing reproduction/regression unit tests.
  - [x] I've reviewed every AI-generated line as if I wrote it myself, and confirm: no PHI shared, no license-incompatible content (Apache-2.0).

---

## PR Procedure

### Coder Tasks

- [x] Rebased / merged `develop` branch; no merge conflicts.
- [x] `uv run pre-commit run --all-files` passes (ruff lint, ruff-format, django-upgrade).
  - `uv run ruff check . --fix` to help resolve linting errors
- [x] `uv run python -Wd manage.py check` reviewed for new deprecation warnings (0 issues).
- [x] `uv run pytest` full test suite passes.
- [x] `uv run python manage.py makemigrations --check --dry-run` (no model migrations introduced).
- [x] Docker builds succeed if touched. (N/A)
- [x] Docs updated under `docs/` if behaviour, settings, or APIs changed. (N/A)
- [x] `release_notes.md` updated if user-facing.
- [x] No secrets, debug code, or stray `print`/`console.log` left in.

### Review Code

- [ ] Reviewer verifies the target branch.
- [ ] For non-trivial changes: pulled the branch, ran it locally, and confirmed it works as described.
- [ ] CI is green; test suite and `pre-commit` pass.
- [ ] Reads through all changed files for anything weird or unintended.
- [ ] Logic is correct; edge cases and error handling considered.
- [ ] Migrations are sane and reversible where possible.
- [ ] Changes are consistent with the modernization direction (no reintroduction
      of patterns being migrated away from, e.g. flake8/yapf-era conventions).
- [ ] No security concerns (input validation, permissions, injection, XSS).
- [ ] Comments are sufficient and not overkill.
- [ ] Typos, spellcheck, professional.
- [ ] Reviewer sends back review.

### Edits

- [ ] Coder fixes any issues.
- [ ] Reviewer approves.

> Maintainer review is required for breaking changes, new features, and migrations.
> For bug fixes, refactors, and docs-only changes, reviewer approval is sufficient to merge.

---

## Testing Notes

- **Model `__str__` and Admin View:** Added unit tests `test_reportschedule_str` and `test_reportnote_str` to [`qatrack/reports/tests/test_base.py`](file:///c:/Users/nsmel/source/repos/qatrackplus/qatrack/reports/tests/test_base.py). Confirmed they failed with `AttributeError` before the fix and passed after. Verified `/admin/reports/reportschedule/<id>/change/` loads with status `200 OK`.
- **Frontend Recurrence Widget:** Tested `/reports/schedule/<id>/` modal endpoint and verified dynamic text interpolation with the JavaScript catalog.
- **Midnight Scheduling Window:** Added `test_run_periodic_scheduler_midnight_crossing` to [`qatrack/qatrack_core/tests/test_django_q2.py`](file:///c:/Users/nsmel/source/repos/qatrackplus/qatrack/qatrack_core/tests/test_django_q2.py).
- **Test Suite Results:**
  - `pytest qatrack/reports/tests/test_base.py -k "not selenium and not driver"` (95 passed)
  - `pytest qatrack/qatrack_core/tests/test_django_q2.py` (15 passed)
  - `python manage.py check` (0 issues)
  - Pre-commit hooks (`ruff`, Django checks) passed.

## Screenshots

N/A
