### PR TITLE
Set language cookie duration

### DIFF
--- a/qatrack/settings.py
+++ b/qatrack/settings.py
@@ -105,6 +105,8 @@ DATETIME_HELP = "Format DD MMM YYYY hh:mm (hh:mm is 24h time e.g. 31 May 2012 14
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en'
+# Duration of the language cookie 
+LANGUAGE_COOKIE_AGE = 360 * 24 * 60 * 60 # 1 year
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.

--- a/qatrack/settings.py
+++ b/qatrack/settings.py
@@ -106,6 +106,7 @@ DATETIME_HELP = "Format DD MMM YYYY hh:mm (hh:mm is 24h time e.g. 31 May 2012 14
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en'
 # Duration of the language cookie 
+# TODO: add nice documentation to the local_settings defaults so deployment is clear. 
 LANGUAGE_COOKIE_AGE = 360 * 24 * 60 * 60 # 1 year
 
 # If you set this to False, Django will make some optimizations so as not


### PR DESCRIPTION
## Summary

Small PR to fix the language cookie's duration. LANGUAGE_COOKIE_AGE was never set, so Django defaults it to session duration. LocaleMiddleware then falls back to the browser's "Accept-Language" http header; so users whose browser isn't set to their desired qatrack language have to re-pick it every day. 

Django's language priority is : cookie > Accept-Language > setting's LANGUAGE_CODE 

## Related Issues

None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature ( adds functionality, always assumed to be breaking until tested by maintainers)
- [ ] Breaking change (fix or addition that changes existing behaviour)
- [ ] Documentation only

## Target Branch

develop

## AI Usage Disclosure

- [x] No AI tools were used in this PR.
- [ ] AI tools were used:
  - **Tools / where used:** _e.g. GitHub Copilot for boilerplate_
  - [ ] I've reviewed every AI-generated line as if I wrote it myself, and confirm: no PHI shared, no license-incompatible content (Apache-2.0).

---

## PR Procedure

### Coder Tasks

- [x] Rebased / merged `develop` branch; no merge conflicts.
- [ ] `uv run pre-commit run --all-files` passes (ruff lint, ruff-format, django-upgrade).
  - `uv run ruff check . --fix` to help resolve linting errors
- [ ] `uv run python -Wd manage.py check` reviewed for new deprecation warnings.
- [ ] `uv run pytest` full test suite passes.
- [ ] `uv run python manage.py makemigrations --check --dry-run` if migrations are found, change should be marked Breaking
- [ ] Docker builds succeed if touched.
- [ ] Docs updated under `docs/` if behaviour, settings, or APIs changed.
- [ ] `release_notes.md` updated if user-facing.
- [ ] No secrets, debug code, or stray `print`/`console.log` left in.

### Review Code

- [x] Reviewer verifies the target branch.
- [x] For non-trivial changes: pulled the branch, ran it locally, and confirmed it works as described.
- [x] CI is green; test suite and `pre-commit` pass.
- [x] Reads through all changed files for anything weird or unintended.
- [x] Logic is correct; edge cases and error handling considered.
- [x] Migrations are sane and reversible where possible.
- [x] Changes are consistent with the modernization direction (no reintroduction
      of patterns being migrated away from, e.g. flake8/yapf-era conventions).
- [x] No security concerns (input validation, permissions, injection, XSS).
- [x] Comments are sufficient and not overkill.
- [x] Typos, spellcheck, professional.
- [ ] Reviewer sends back review.

### Edits

- [x] Coder fixes any issues.
- [ ] Reviewer approves.

> Maintainer review is required for breaking changes, new features, and migrations.
> For bug fixes, refactors, and docs-only changes, reviewer approval is sufficient to merge.

---

## Testing Notes

Restart the django docker, then check if the language cookie duration expires in one year.

## Screenshots

None

exited by @crcrewso for minor markdown style changes
